### PR TITLE
[FEAT] 로그인 API 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/helmet": "^4.0.0",
+    "@types/jsonwebtoken": "^8.5.8",
     "@types/mongoose": "^5.11.97",
     "@types/node": "^17.0.25",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
@@ -33,6 +34,7 @@
     "express": "^4.17.3",
     "express-validator": "^6.14.0",
     "helmet": "^5.1.0",
+    "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.3.1",
     "prettier": "^2.7.1"
   }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -17,6 +17,12 @@ export default {
   port: parseInt(process.env.PORT as string, 10),
 
   /**
+   * jwt
+   */
+  jwtSecret: process.env.JWT_SECRET as string,
+  jwtAlgo: process.env.JWT_ALGO as string,
+
+  /**
    * MongoDB URI
    */
   mongoURI: process.env.MONGODB_URI as string,

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -2,6 +2,10 @@ import { NextFunction, Response } from 'express';
 import { validationResult } from 'express-validator';
 import Request, { IllegalArgumentException } from '../intefaces/common';
 import CreateUserCommand from '../intefaces/createUserCommand';
+import { PostBaseResponseDto } from '../intefaces/PostBaseResponseDto';
+import { UserLoginDto } from '../intefaces/UserLoginDto';
+import User from '../models/user';
+import getToken from '../modules/jwtHandler';
 import message from '../modules/responseMessage';
 import statusCode from '../modules/statusCode';
 import util from '../modules/util';
@@ -32,4 +36,32 @@ const postUser = async (
   }
 };
 
-export default { postUser };
+/**
+ *  @route /users/login
+ *  @desc 로그인 api
+ *  @access Public
+ */
+const loginUser = async (req: Request, res: Response, next: NextFunction) => {
+  const error = validationResult(req);
+
+  if (!error.isEmpty) {
+    throw new IllegalArgumentException('필요한 값이 없습니다.');
+  }
+
+  const userLoginDto: UserLoginDto = req.body;
+  try {
+    const result = await UserService.loginUser(userLoginDto);
+    const accessToken = getToken((result as PostBaseResponseDto)._id);
+    const data = {
+      _id: (result as PostBaseResponseDto)._id,
+      accessToken
+    };
+    return res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.USER_LOGIN_SUCCESS, data));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export default { postUser, loginUser };

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -50,7 +50,9 @@ const loginUser = async (req: Request, res: Response, next: NextFunction) => {
 
   const userLoginDto: UserLoginDto = req.body;
   try {
-    const result = await UserService.loginUser(userLoginDto);
+    const result: PostBaseResponseDto = await UserService.loginUser(
+      userLoginDto
+    );
     const accessToken = getToken((result as PostBaseResponseDto)._id);
     const data = {
       _id: (result as PostBaseResponseDto)._id,

--- a/src/intefaces/JwtPayloadInfo.ts
+++ b/src/intefaces/JwtPayloadInfo.ts
@@ -1,0 +1,7 @@
+import { Types } from 'mongoose';
+
+export interface JwtPayloadInfo {
+  user: {
+    id: Types.ObjectId;
+  };
+}

--- a/src/intefaces/PostBaseResponseDto.ts
+++ b/src/intefaces/PostBaseResponseDto.ts
@@ -1,0 +1,5 @@
+import { Types } from "mongoose";
+
+export interface PostBaseResponseDto {
+  _id: Types.ObjectId;
+}

--- a/src/intefaces/UserLoginDto.ts
+++ b/src/intefaces/UserLoginDto.ts
@@ -1,0 +1,4 @@
+export interface UserLoginDto {
+  email: string;
+  password: string;
+}

--- a/src/intefaces/common.ts
+++ b/src/intefaces/common.ts
@@ -13,3 +13,5 @@ export class PiickleException extends Error {
 }
 
 export class IllegalArgumentException extends PiickleException {}
+export class BadCredentialException extends PiickleException {}
+export class InternalAuthenticationServiceException extends PiickleException {}

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,0 +1,37 @@
+import express, { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import config from '../config';
+import statusCode from '../modules/statusCode';
+import message from '../modules/responseMessage';
+import util from '../modules/util';
+
+export default (req: Request, res: Response, next: NextFunction) => {
+  const token = req.headers['authorization']?.split(' ').reverse()[0];
+
+  if (!token) {
+    return res
+      .status(statusCode.UNAUTHORIZED)
+      .send(util.fail(statusCode.UNAUTHORIZED, message.NULL_VALUE_TOKEN));
+  }
+
+  try {
+    const decoded = jwt.verify(token, config.jwtSecret);
+    req.body.user = (decoded as any).user;
+    next();
+  } catch (error: any) {
+    console.log(error);
+    if (error.name == 'TokenExpiredError') {
+      return res
+        .status(statusCode.UNAUTHORIZED)
+        .send(util.fail(statusCode.UNAUTHORIZED, message.NULL_VALUE_TOKEN));
+    }
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .send(
+        util.fail(
+          statusCode.INTERNAL_SERVER_ERROR,
+          message.INTERNAL_SERVER_ERROR
+        )
+      );
+  }
+};

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -6,7 +6,7 @@ import message from '../modules/responseMessage';
 import util from '../modules/util';
 
 export default (req: Request, res: Response, next: NextFunction) => {
-  const token = req.headers['authorization']?.split(' ').reverse()[0];
+  const token = req.header('x-auth-token')?.split(' ').reverse()[0];
 
   if (!token) {
     return res
@@ -23,7 +23,7 @@ export default (req: Request, res: Response, next: NextFunction) => {
     if (error.name == 'TokenExpiredError') {
       return res
         .status(statusCode.UNAUTHORIZED)
-        .send(util.fail(statusCode.UNAUTHORIZED, message.NULL_VALUE_TOKEN));
+        .send(util.fail(statusCode.UNAUTHORIZED, message.EXPIRED_TOKEN));
     }
     return res
       .status(statusCode.INTERNAL_SERVER_ERROR)

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,6 +1,8 @@
 import { NextFunction, Response } from 'express';
 import Request, {
   IllegalArgumentException,
+  BadCredentialException,
+  InternalAuthenticationServiceException,
   PiickleException
 } from '../intefaces/common';
 import message from '../modules/responseMessage';
@@ -19,6 +21,16 @@ export default (
       return res
         .status(statusCode.BAD_REQUEST)
         .send(util.fail(statusCode.BAD_REQUEST, message.NULL_VALUE));
+    }
+    if (err instanceof BadCredentialException) {
+      return res
+        .status(statusCode.UNAUTHORIZED)
+        .send(util.fail(statusCode.UNAUTHORIZED, err.message));
+    }
+    if (err instanceof InternalAuthenticationServiceException) {
+      return res
+        .status(statusCode.UNAUTHORIZED)
+        .send(util.fail(statusCode.UNAUTHORIZED, err.message));
     }
     return res
       .status(statusCode.BAD_REQUEST)

--- a/src/modules/jwtHandler.ts
+++ b/src/modules/jwtHandler.ts
@@ -1,0 +1,20 @@
+import jwt from 'jsonwebtoken';
+import { Types } from 'mongoose';
+import config from '../config';
+import { JwtPayloadInfo } from '../intefaces/JwtPayloadInfo';
+
+const getToken = (userId: Types.ObjectId): string => {
+  const payload: JwtPayloadInfo = {
+    user: {
+      id: userId
+    }
+  };
+
+  const accessToken: string = jwt.sign(payload, config.jwtSecret, {
+    expiresIn: '2h'
+  });
+
+  return accessToken;
+};
+
+export default getToken;

--- a/src/modules/jwtHandler.ts
+++ b/src/modules/jwtHandler.ts
@@ -11,7 +11,7 @@ const getToken = (userId: Types.ObjectId): string => {
   };
 
   const accessToken: string = jwt.sign(payload, config.jwtSecret, {
-    expiresIn: '2h'
+    expiresIn: '24h'
   });
 
   return accessToken;

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -1,9 +1,11 @@
 const message = {
   USER_CREATED: '회원가입 성공',
   NULL_VALUE: '필요한 값이 없습니다.',
+  NULL_VALUE_TOKEN: '토큰이 유효하지 않습니다.',
   NOT_FOUND: '존재하지 않는 자원',
   BAD_REQUEST: '잘못된 요청',
-  INTERNAL_SERVER_ERROR: '서버 내부 오류'
+  INTERNAL_SERVER_ERROR: '서버 내부 오류',
+  USER_LOGIN_SUCCESS: '로그인 성공'
 };
 
 export default message;

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -5,7 +5,8 @@ const message = {
   NOT_FOUND: '존재하지 않는 자원',
   BAD_REQUEST: '잘못된 요청',
   INTERNAL_SERVER_ERROR: '서버 내부 오류',
-  USER_LOGIN_SUCCESS: '로그인 성공'
+  USER_LOGIN_SUCCESS: '로그인 성공',
+  EXPIRED_TOKEN: '만료된 토큰입니다.'
 };
 
 export default message;

--- a/src/routes/userRouter.ts
+++ b/src/routes/userRouter.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { body } from 'express-validator';
 import { UserController } from '../controllers';
+import auth from '../middlewares/auth';
 
 const router = Router();
 
@@ -13,6 +14,13 @@ router.post(
     body('nickname').notEmpty()
   ],
   UserController.postUser
+);
+
+router.post(
+  '/login',
+  auth,
+  [body('email').notEmpty(), body('password').notEmpty()],
+  UserController.loginUser
 );
 
 export default router;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,8 +1,15 @@
 import { hashSync } from 'bcrypt';
+import { compare } from 'bcrypt';
 import config from '../config';
 import CreateUserCommand from '../intefaces/createUserCommand';
 import User from '../models/user';
-import { IllegalArgumentException } from '../intefaces/common';
+import {
+  IllegalArgumentException,
+  InternalAuthenticationServiceException,
+  BadCredentialException
+} from '../intefaces/common';
+import { UserLoginDto } from '../intefaces/UserLoginDto';
+import { PostBaseResponseDto } from '../intefaces/PostBaseResponseDto';
 
 const createUser = async (command: CreateUserCommand) => {
   const alreadyUser = await User.findOne({
@@ -22,4 +29,28 @@ const createUser = async (command: CreateUserCommand) => {
   await user.save();
 };
 
-export default { createUser };
+const loginUser = async (
+  userLoginDto: UserLoginDto
+): Promise<PostBaseResponseDto | null> => {
+  const user = await User.findOne({
+    email: userLoginDto.email
+  });
+
+  if (!user) {
+    throw new InternalAuthenticationServiceException(
+      '존재하지 않는 email 입니다.'
+    );
+  }
+
+  const isMatch = await compare(user.hashedPassword, userLoginDto.password);
+  if (!isMatch) {
+    throw new BadCredentialException('비밀번호가 일치하지 않습니다.');
+  }
+
+  const data = {
+    _id: user._id
+  };
+  return data;
+};
+
+export default { createUser, loginUser };

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -31,7 +31,7 @@ const createUser = async (command: CreateUserCommand) => {
 
 const loginUser = async (
   userLoginDto: UserLoginDto
-): Promise<PostBaseResponseDto | null> => {
+): Promise<PostBaseResponseDto> => {
   const user = await User.findOne({
     email: userLoginDto.email
   });


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-0



**변경사항**

* close #6 
* 이슈 참조
* userLogin API 구현
* login error handler 추가

**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

* 로그인 성공했을때 id와 jwt 토큰을 같이 넘겨주는데 이때 jwt 토큰에 id 가 담겨 있어서 두번 넘겨줄 필요가 있나 한번 생각해주세요!

**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->