### PR TITLE
[FEAT] 베스트 카드 (베스트 피클) 리스트 조회

### DIFF
--- a/src/controllers/cardController.ts
+++ b/src/controllers/cardController.ts
@@ -1,5 +1,4 @@
-import { NextFunction, Response } from 'express';
-import Request from '../intefaces/common';
+import { NextFunction, Request, Response } from 'express';
 import message from '../modules/responseMessage';
 import statusCode from '../modules/statusCode';
 import util from '../modules/util';
@@ -12,7 +11,7 @@ import { CardService } from '../services';
  */
 const getBest5 = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const cards = await CardService.findBestCards();
+    const cards = await CardService.findBestCards(5);
     return res
       .status(statusCode.OK)
       .send(
@@ -24,4 +23,4 @@ const getBest5 = async (req: Request, res: Response, next: NextFunction) => {
   }
 };
 
-export default { getBest5 };
+export { getBest5 };

--- a/src/controllers/cardController.ts
+++ b/src/controllers/cardController.ts
@@ -1,0 +1,27 @@
+import { NextFunction, Response } from 'express';
+import Request from '../intefaces/common';
+import message from '../modules/responseMessage';
+import statusCode from '../modules/statusCode';
+import util from '../modules/util';
+import { CardService } from '../services';
+
+/**
+ *  @route /cards/best-5
+ *  @desc 이번 달의 베스트 피클을 가져옵니다.
+ *  @access Public
+ */
+const getBest5 = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const cards = await CardService.findBestCards();
+    return res
+      .status(statusCode.OK)
+      .send(
+        util.success(statusCode.OK, message.READ_BEST_CARDS_SUCCESS, cards)
+      );
+  } catch (err) {
+    console.log(err);
+    next(err);
+  }
+};
+
+export default { getBest5 };

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,5 +1,6 @@
 import * as UserController from './userController';
 import * as CategoryController from './CategoryController';
 import * as BallotController from './ballotController';
+import * as CardController from './cardController';
 
-export { UserController, CategoryController, BallotController };
+export { UserController, CategoryController, BallotController, CardController };

--- a/src/intefaces/CardResponseDto.ts
+++ b/src/intefaces/CardResponseDto.ts
@@ -1,6 +1,7 @@
 import { Types } from 'mongoose';
 
 export interface CardResponseDto {
+  _id: Types.ObjectId;
   content: string;
   tags: string[];
   category: Types.ObjectId[];

--- a/src/intefaces/CategoryResponseDto.ts
+++ b/src/intefaces/CategoryResponseDto.ts
@@ -1,6 +1,8 @@
 import { CardResponseDto } from './CardResponseDto';
+import { Types } from 'mongoose';
 
 export default interface CategoryResponseDto {
+  _id: Types.ObjectId;
   title: string;
   cardList: CardResponseDto[];
 }

--- a/src/models/card.ts
+++ b/src/models/card.ts
@@ -11,9 +11,7 @@ const cardSchema = new Schema<CardDocument>({
   },
   tags: [String],
   category: [Schema.Types.ObjectId],
-  filter: {
-    type: [String]
-  }
+  filter: [String]
 });
 
 const Card = model<CardDocument>('Card', cardSchema);

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -19,6 +19,7 @@ const message = {
   //카드
   SEARCH_CARDS_SUCCESS: '필터에 해당하는 카드들 읽어오기 성공',
   READ_CARD_SUCCESS: '카테고리에 해당 카드 읽어오기 성공',
+  READ_BEST_CARDS_SUCCESS: '베스트 카드 읽어오기 성공',
 
   // 투표
   BALLOT_RESULT_CREATED: '투표 성공'

--- a/src/modules/util.ts
+++ b/src/modules/util.ts
@@ -13,6 +13,11 @@ const util = {
       success: false,
       message
     };
+  },
+  getLastMonth: (): Date => {
+    const beforeAMonth = new Date();
+    beforeAMonth.setMonth(beforeAMonth.getMonth() - 1);
+    return beforeAMonth;
   }
 };
 

--- a/src/routes/cardRouter.ts
+++ b/src/routes/cardRouter.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { CardController } from '../controllers';
+
+const router = Router();
+
+router.get('/best-5', CardController.getBest5);
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,11 +3,13 @@ import { Router } from 'express';
 import UserRouter from './userRouter';
 import CategoryRouter from './CategoryRouter';
 import BallotRouter from './ballotRouter';
+import CardRouter from './cardRouter';
 
 const router = Router();
 
 router.use('/users', UserRouter);
 router.use('/categories', CategoryRouter);
 router.use('/ballots', BallotRouter);
+router.use('/cards', CardRouter);
 
 export default router;

--- a/src/services/cardService.ts
+++ b/src/services/cardService.ts
@@ -1,0 +1,20 @@
+import Bookmark from '../models/bookmark';
+import Card from '../models/card';
+
+const findBestCards = async (size: number) => {
+  const beforeAMonth = new Date();
+  beforeAMonth.setMonth(beforeAMonth.getMonth() - 1);
+
+  const cardIdAndCnt = await Bookmark.aggregate([
+    { $match: { createdAt: { $gte: beforeAMonth } } }
+  ])
+    .sortByCount('card')
+    .limit(size);
+  const cards = await Promise.all(
+    cardIdAndCnt.map(async c => {
+      return Card.findById(c._id);
+    })
+  );
+  return cards;
+};
+export { findBestCards };

--- a/src/services/cardService.ts
+++ b/src/services/cardService.ts
@@ -15,6 +15,13 @@ const findBestCards = async (size: number) => {
       return Card.findById(c._id, '_id category content');
     })
   );
-  return cards;
+
+  let extraCard;
+  if (cards.length < size) {
+    extraCard = await Card.find({ _id: { $nin: cards.map(c => c._id) } }).limit(
+      size - cards.length
+    );
+  }
+  return [...cards, ...extraCard];
 };
 export { findBestCards };

--- a/src/services/cardService.ts
+++ b/src/services/cardService.ts
@@ -1,22 +1,27 @@
 import Bookmark from '../models/bookmark';
 import Card from '../models/card';
+import util from '../modules/util';
+import { Types } from 'mongoose';
+import { CardResponseDto } from '../intefaces/CardResponseDto';
+interface CardIdAndCnt {
+  _id: Types.ObjectId;
+  count: number;
+}
 
 const findBestCards = async (size: number) => {
-  const beforeAMonth = new Date();
-  beforeAMonth.setMonth(beforeAMonth.getMonth() - 1);
-
-  const cardIdAndCnt = await Bookmark.aggregate([
-    { $match: { createdAt: { $gte: beforeAMonth } } }
+  const cardIdAndCnt = <CardIdAndCnt[]>await Bookmark.aggregate([
+    { $match: { createdAt: { $gte: util.getLastMonth() } } }
   ])
     .sortByCount('card')
     .limit(size);
-  const cards = await Promise.all(
+
+  const cards = <CardResponseDto[]>await Promise.all(
     cardIdAndCnt.map(async c => {
       return Card.findById(c._id, '_id category content');
     })
   );
 
-  let extraCard;
+  let extraCard: CardResponseDto[] = [];
   if (cards.length < size) {
     extraCard = await Card.find({ _id: { $nin: cards.map(c => c._id) } }).limit(
       size - cards.length

--- a/src/services/cardService.ts
+++ b/src/services/cardService.ts
@@ -12,7 +12,7 @@ const findBestCards = async (size: number) => {
     .limit(size);
   const cards = await Promise.all(
     cardIdAndCnt.map(async c => {
-      return Card.findById(c._id);
+      return Card.findById(c._id, '_id category content');
     })
   );
   return cards;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,5 @@
 import * as UserService from './userService';
 import * as CategoryService from './CategoryService';
 import * as BallotService from './ballotService';
-export { UserService, CategoryService, BallotService };
+import * as CardService from './cardService';
+export { UserService, CategoryService, BallotService, CardService };


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-1



**변경사항**

- closes: #15 
- 해당 달의 베스트 카드 5개를 조회하는 기능입니다.

**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

- 저는 베스트 카드를 북마크 스키마를 통해 가져왔습니다. 그렇기 때문에 고려해야할 사항이 한 가지 있는데요
- 실제로 그런 경우가 드물긴 하겠지만, 월 초에 북마크를 받은 카드가 5개 이하인 경우에는 북마크 스키마를 통해 카드를 가져오면 카드가 5개 미만이 됩니다.

```typescript
// cardService.ts
  if (cards.length < size) {
    extraCard = await Card.find({ _id: { $nin: cards.map(c => c._id) } }).limit(
      size - cards.length
    );
  }
```
- 그래서 5개 이하인 경우에 추가로 카드스키마에서 무작위로 모자른 개수만큼 더 가져옵니다.
- 로직이 비효율적일 수 있지만 최대 5개이니까 여기까지만 생각해보려 합니다.

- 더 나은 방법이 있거나 잘못된 것이 있다면 알려주세요!


**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->