### PR TITLE
[FEAT] 비밀번호 변경

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -178,11 +178,32 @@ const getBookmarks = async (
   }
 };
 
+/**
+ *  @route /users/me/password
+ *  @desc 비밀번호 수정 API
+ *  @access Public
+ */
+const patchUserPassword = async (
+  req: TypedRequest<{ newPassword: string }>,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const { newPassword } = req.body;
+    const userId = <Types.ObjectId>req.user.id;
+    await UserService.updatePassword(userId, newPassword);
+  } catch (err) {
+    console.log(err);
+    next(err);
+  }
+};
+
 export {
   postUser,
   loginUser,
   getUserProfile,
   updateUserNickname,
   updateUserProfileImage,
-  getBookmarks
+  getBookmarks,
+  patchUserPassword
 };

--- a/src/routes/userRouter.ts
+++ b/src/routes/userRouter.ts
@@ -40,4 +40,10 @@ router.patch(
   UserController.updateUserNickname
 );
 
+router.patch(
+  '/me/password',
+  auth,
+  [body('newPassword').notEmpty()],
+  UserController.patchUserPassword
+);
 export default router;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -128,11 +128,22 @@ const getBookmarks = async (
   return bookmarks;
 };
 
+const updatePassword = async (userId: Types.ObjectId, newPassword: string) => {
+  const user = await User.findById(userId);
+  if (!user) {
+    throw new IllegalArgumentException('존재하지 않는 유저 id 입니다.');
+  }
+  const hashedPassword = hashSync(newPassword, 10);
+  user.hashedPassword = hashedPassword;
+  await user.save();
+};
+
 export {
   createUser,
   loginUser,
   findUserById,
   updateNickname,
   updateUserProfileImage,
-  getBookmarks
+  getBookmarks,
+  updatePassword
 };


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-2



**변경사항**

- closes: #33 
- 로그아웃 상태에서 비밀번호 바꾸는 기능입니다

**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

- 처음에 로그인한 상태로 비밀번호 변경하는 거 만들어버렸어요
- 그래서 두개입니다..

- 로그아웃 상태에서의 비밀번호 변경플로우는 다음과 같습니다. 일단 EmailAuth 스키마를 같이 보시죵

```typescript
const emailAuthSchema = new Schema<EmailAuthDocument>(
  {
    email: {
      type: String,
      required: true
    },
    isVerified: {
      type: Boolean,
      required: true
    },
    expiresIn: {
      type: Date,
      required: true
    },
    code: {
      type: String,
      required: false
    }
  },
  {
    timestamps: true
  }
);
```

1. 유저가 입력한 이메일로 인증메일을 보냅니다. `👉🏻 이때 emailAuth document 하나가 생성됩니다`
2. 유저가 메일 인증을 완료 합니다. `👉🏻 emailAuth의 isVerified가 true가 됩니다.`
3. 인증 받은 메일 주소와 새 비밀번호를 담아 비밀번호 변경 요청을 보냅니다.
4. 비밀번호 변경 끝!

**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->