### PR TITLE
[FEAT] 닉네임 중복체크 api 구현

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -49,6 +49,31 @@ const sendEmailVerification = async (
 };
 
 /**
+ *  @route GET /users/nickname
+ *  @desc 닉네임 중복 체크 api
+ *  @access Public
+ */
+const nicknameDuplicationCheck = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const { nickname } = req.query;
+    console.log(nickname);
+    if (!nickname) {
+      throw new IllegalArgumentException('필요한 값이 없습니다.');
+    }
+    const result = await UserService.nicknameDuplicationCheck(<string>nickname);
+    res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, '닉네임 중복 체크 성공', result));
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
  *
  * @method GET
  * @route /email-check
@@ -311,5 +336,6 @@ export {
   getBookmarks,
   createdeleteBookmark,
   sendEmailVerification,
-  verifyEmail
+  verifyEmail,
+  nicknameDuplicationCheck
 };

--- a/src/routes/userRouter.ts
+++ b/src/routes/userRouter.ts
@@ -13,6 +13,9 @@ router.post(
 );
 
 router.get('/email-check', UserController.verifyEmail);
+
+router.get('/nickname/is-exist', UserController.nicknameDuplicationCheck);
+
 router.post(
   '',
   [

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -172,6 +172,15 @@ const createdeleteBookmark = async (input: UserBookmarkInfo) => {
   }
 };
 
+const nicknameDuplicationCheck = async (nickname: string) => {
+  const user = await User.findOne({
+    nickname: nickname
+  });
+  if (user) {
+    return true;
+  }
+  return false;
+};
 export {
   createUser,
   loginUser,
@@ -179,5 +188,6 @@ export {
   updateNickname,
   updateUserProfileImage,
   getBookmarks,
-  createdeleteBookmark
+  createdeleteBookmark,
+  nicknameDuplicationCheck
 };


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-2



**변경사항**

* close #119 

**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

* 생각보다 코드가 매우 짧네요.
* 반환 statusCode 는 중복이냐 아니냐 상관없이 모두 200으로 주었고 boolean 값을 통해서 판단할수 있게 구현했습니다.

**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->