### PR TITLE
[FEAT] 카테고리별 그라데이션 필드 추가

### DIFF
--- a/src/models/category.ts
+++ b/src/models/category.ts
@@ -10,14 +10,17 @@ const categorySchema = new Schema<CategoryDocument>({
     required: true
   },
   content: String,
-  imgurl: String,
   cardIdList: [
     {
       type: Schema.Types.ObjectId,
       ref: 'Card'
     }
   ],
-  unicode: String
+  gradation: String,
+  order: {
+    type: Number,
+    unique: true
+  }
 });
 
 const Category = model<CategoryDocument>('Category', categorySchema);

--- a/src/models/interface/ICategory.ts
+++ b/src/models/interface/ICategory.ts
@@ -3,7 +3,7 @@ import { Types } from 'mongoose';
 export default interface ICategory {
   title: string;
   content: string;
-  imgurl: string;
   cardIdList: Types.ObjectId[];
-  unicode: string;
+  gradation: string;
+  order: number;
 }

--- a/src/services/CategoryService.ts
+++ b/src/services/CategoryService.ts
@@ -14,10 +14,10 @@ const getCategory = async (): Promise<Array<object> | null> => {
     {
       title: 1,
       content: 2,
-      imgurl: 3,
-      unicode: 4
+      unicode: 3,
+      gradation: 4
     }
-  ).sort({ __v: 1 });
+  ).sort({ order: 1 });
   if (!categories) return null;
 
   return categories;


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-0



**변경사항**
- 카테고리 스키마에서 img url은 삭제
- 그라데이션 값을 string으로 추가했습니다 (rdb에서는 text를 사용할 것 같습니다)
- 원하는 순서로 정렬하기 위해서 order 필드를 추가했어요 (기존에는 데이터베이스 디폴트 순서로 응답하고 있었습니다)


**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->



**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->