### PR TITLE
[FIX] 카드 메들리 조회 시 카드 순서를 랜덤화

### DIFF
--- a/src/modules/util.ts
+++ b/src/modules/util.ts
@@ -51,6 +51,23 @@ const util = {
     if (value === null || value === undefined) return false;
     const testDummy: T = value;
     return true;
+  },
+  shuffle: <T>(array: T[]) => {
+    let currentIndex = array.length,
+      randomIndex;
+
+    while (currentIndex != 0) {
+      // Pick a remaining element.
+      randomIndex = Math.floor(Math.random() * currentIndex);
+      currentIndex--;
+
+      // And swap it with the current element.
+      [array[currentIndex], array[randomIndex]] = [
+        array[randomIndex],
+        array[currentIndex]
+      ];
+    }
+    return array;
   }
 };
 

--- a/src/modules/util.ts
+++ b/src/modules/util.ts
@@ -57,11 +57,9 @@ const util = {
       randomIndex;
 
     while (currentIndex != 0) {
-      // Pick a remaining element.
       randomIndex = Math.floor(Math.random() * currentIndex);
       currentIndex--;
 
-      // And swap it with the current element.
       [array[currentIndex], array[randomIndex]] = [
         array[randomIndex],
         array[currentIndex]

--- a/src/services/cardMedleyService.ts
+++ b/src/services/cardMedleyService.ts
@@ -6,6 +6,7 @@ import CardMedleyPreviewDto from '../intefaces/CardMedleyPreviewDto';
 import Bookmark from '../models/bookmark';
 import { CardResponseDto } from '../intefaces/CardResponseDto';
 import { Types } from 'mongoose';
+import util from '../modules/util';
 
 const getCardsById = async (
   id: string,
@@ -44,7 +45,7 @@ const getCardsById = async (
     title: cardMedley.title,
     description: cardMedley.description,
     previewCards: cardMedley.previewCards,
-    cards: cardDtos
+    cards: util.shuffle(cardDtos)
   };
 };
 


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-0



**변경사항**

- 카드 메들리 조회 시마다 순서는 랜덤하도록 애플리케이션에서 조작


**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->



**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->

승헌 요청입니다
https://w1655692613-dsw141740.slack.com/archives/C04FGQCL894/p1681237055993269