### PR TITLE
[HOTFIX] 최근 북마크 된 카드 조회 시 중복 제거

### DIFF
--- a/src/services/cardService.ts
+++ b/src/services/cardService.ts
@@ -122,6 +122,11 @@ const findRecentlyUpdatedCard = async (userId?: Types.ObjectId) => {
 
 const findRecentlyBookmarkedCard = async (userId?: Types.ObjectId) => {
   const bookmarks: BookmarkDocument[] = await Bookmark.aggregate()
+    .group({
+      _id: '$card',
+      card: { $first: '$card' },
+      createdAt: { $first: '$createdAt' }
+    })
     .sort({ createdAt: -1 })
     .limit(20);
   const cards: CardDocument[] = (


### PR DESCRIPTION
**우선순위**



**변경사항**
* 최근 북마크 된 카드 조회시 중복 된 카드가 나오는 버그 수정


**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->



**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->