### PR TITLE
chore: changed image url prefix

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -41,4 +41,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TOKEN_FOR_PR }}
           FROM_BRANCH: "main"
           TO_BRANCH: "develop"
-          PULL_REQUEST_TITLE: "sync: ${{ github.ref_name || github.ref }} -> main -> develop"
+          PULL_REQUEST_TITLE: "sync: main -> develop"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -68,5 +68,6 @@ export default {
   /**
    * piickle service application url
    */
-  webAppUrl: WEB_APP_URL as string
+  webAppUrl: WEB_APP_URL as string,
+  imageServerUrl: process.env.IMAGE_SERVER_URL as string
 };

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -363,12 +363,15 @@ const updateUserProfileImage = async (
       throw new IllegalArgumentException('필요한 값이 없습니다.');
     }
     const image = req.file as Express.MulterS3.File;
-    const { location } = image;
+    const { key } = image;
     const userId = req.user?.id;
     if (!userId) {
       throw new IllegalArgumentException('로그인이 필요합니다.');
     }
-    const data = await UserService.updateUserProfileImage(userId, location);
+    const data = await UserService.updateUserProfileImage(
+      userId,
+      `${config.imageServerUrl}/${key}`
+    );
     return res
       .status(statusCode.OK)
       .send(

--- a/src/intefaces/createUserCommand.ts
+++ b/src/intefaces/createUserCommand.ts
@@ -1,3 +1,4 @@
+import config from '../config';
 import { AgeGroup, AgeGroupKey } from '../models/user/ageGroup';
 import { Gender, GenderKey } from '../models/user/gender';
 import { TypedRequest } from '../types/TypedRequest';
@@ -28,7 +29,9 @@ const toCommand = (req: TypedRequest<CreateUserReq>) => {
       ? AgeGroup[req.body.ageGroup]
       : AgeGroup.UNDEFINED,
     gender: req.body.gender ? Gender[req.body.gender] : Gender.ETC,
-    profileImgUrl: (req?.file as Express.MulterS3.File)?.location
+    profileImgUrl: `${config.imageServerUrl}/${
+      (req?.file as Express.MulterS3.File)?.key
+    }`
   };
   return createUserCommand;
 };


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-0



**변경사항**

- 계정을 옮기면서 s3 버킷도 새로 만들어주었어요.
  - 기존에 데이터베이스에 저장되어있는 이미지 url 이 s3 Object url 이었기 때문에 버킷을 변경하면서 아주 불편했습니다.
  - 그래서 cloudfront를 연결해 https 를 활성화해줬고, alternative domain을 지정해줬습니다. 앞으로는 버킷을 옮기더라도 DNS 레코드가 가리키는 값만 바꾸면 됩니다.
- 버킷명, credentials 등 대부분 시크릿 변수에 있어 큰 변경은 없었어요.
- 이 PR의 변경사항은 기존에 변경을 고려하지 못해 불가피하게 바꿔야하는 부분입니다.


**유의사항**
<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

- [x] 업로드 테스트
- [x] 데이터베이스 url 변경

+) 이번에 prefix를 바꾸면서 어쩔 수 없이 db에 저장된 url의 prefix를 직접 업데이트 해주었어요. 이 방식이 불편하고 안전하지도 않아서 DB에는 s3 객체 키만 저장하고, 애플리케이션에서 prefix를 더해서 응답할까 잠깐 고민했는데요, 소셜로 가입한 회원들 중에 이미지 동의한 회원들의 프로필이미지 url 은 해당 소셜에서 제공한 url 이라 고민을 기각했습니다. 시험기간이라 시간도 많지 않고요.

- [ ] 배포 전에 새로운 시크릿을 반영해줘야합니다.


**참조**
<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->